### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/MorseBlink/keywords.txt
+++ b/MorseBlink/keywords.txt
@@ -1,4 +1,4 @@
-MorseBlink KEYWORD1
-blinkString KEYWORD2
-blinkChar KEYWORD2
+MorseBlink	KEYWORD1
+blinkString	KEYWORD2
+blinkChar	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords